### PR TITLE
Changed SONAME of library to minor version due to problems with

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,7 +228,7 @@ endif()
 
 add_library(sdk_dslink_c SHARED ${LIBRARY_SRC})
 target_link_libraries(sdk_dslink_c jansson libuv ${DSLINK_PLATFORM_LIBS})
-set_target_properties(sdk_dslink_c PROPERTIES VERSION ${VERSION} SOVERSION ${VERSION_MAJOR} )
+set_target_properties(sdk_dslink_c PROPERTIES VERSION ${VERSION} SOVERSION ${VERSION} )
 
 set(DSLINK_INSTALL_LIB_DIR lib CACHE PATH "Installation directory for libraries")
 set(DSLINK_INSTALL_BIN_DIR bin CACHE PATH "Installation directory for executables")


### PR DESCRIPTION
unpacking soft links with the dart LCM

Installing a dslink with a newer version of the SDK as shared library will fail. The unzip used inthe DART LCM does not restore softlink correctly. Instead you end up with a file containing the name of the link target. 