### PR TITLE
(EAF-1557) Fixed compiler error

### DIFF
--- a/broker/include/broker/subscription.h
+++ b/broker/include/broker/subscription.h
@@ -61,7 +61,7 @@ int broker_update_sub_stream_value(BrokerSubStream *stream, json_t *value, json_
 
 void broker_update_stream_qos(BrokerSubStream *stream);
 void broker_update_sub_qos(SubRequester *req, uint8_t qos);
-void serialize_qos_queue(SubRequester *subReq, uint8_t delete);
+void serialize_qos_queue(SubRequester *subReq, uint8_t deleteFlag);
 
 int check_subscription_ack(RemoteDSLink *link, uint32_t ack);
 


### PR DESCRIPTION
Required for a fix in the Life cycle manager now including the subscription.h in a c++ source file.