### PR TITLE
Feature/eaf 1602 subscribe callback

### DIFF
--- a/sdk/include/dslink/requester.h
+++ b/sdk/include/dslink/requester.h
@@ -23,6 +23,7 @@ typedef struct SubscribeCallbackHolder {
  */
 ref_t* dslink_requester_list(DSLink *link, const char *path, request_handler_cb cb);
 ref_t* dslink_requester_subscribe(DSLink *link, const char *path, value_sub_cb cbs, int qos);
+ref_t* dslink_requester_subscribe2(DSLink *link, const char *path, value_sub_cb cbs, int qos, request_handler_cb cb);
 ref_t* dslink_requester_unsubscribe(DSLink *link, uint32_t sid);
 ref_t* dslink_requester_set(DSLink *link, const char *path, json_t *value);
 ref_t* dslink_requester_remove(DSLink *link, const char *path);

--- a/sdk/src/log.c
+++ b/sdk/src/log.c
@@ -1,3 +1,4 @@
+
 #define LOG_TAG "log"
 
 #include <time.h>


### PR DESCRIPTION
In the current implementation there is no callback inside the requester_subscription notifying about the subscription being in place now. 
For reproduce-able test its import to get a feedback about the subscription being active before start sending data. Otherwise the first updates will be lost (and hopefully the test will fail) The only working solution is to wait a "sufficient" amount of time and hope the subscription is really in place before sending data. 
