### PR TITLE
(EAF-2069) Reconnect upstream due to hearbeat response missing

### DIFF
--- a/broker/src/broker.c
+++ b/broker/src/broker.c
@@ -269,7 +269,9 @@ void broker_close_link(RemoteDSLink *link) {
         }
         dslink_socket_close_nofree(link->client->sock);
     }
-    if (link->dsId) {
+    if (link->isUpstream) {
+      log_info("Upstream %s has disconnected\n", link->name );      
+    } else if (link->dsId) {
         log_info("DSLink `%s` has disconnected\n", (char *) link->dsId->data);
     } else {
         log_info("DSLink `%s` has disconnected\n", (char *) link->name);

--- a/broker/src/handshake.c
+++ b/broker/src/handshake.c
@@ -257,6 +257,7 @@ void dslink_handle_ping(uv_timer_t* handle) {
         gettimeofday(&current_time, NULL);
         long time_diff = current_time.tv_sec - link->lastWriteTime->tv_sec;
         if (time_diff >= 60) {
+            log_debug("dslink_handle_ping send heartbeat to %s\n", link->name );
             broker_ws_send_obj(link, json_object());
         }
     } else {
@@ -268,6 +269,7 @@ void dslink_handle_ping(uv_timer_t* handle) {
         gettimeofday(&current_time, NULL);
         long time_diff = current_time.tv_sec - link->lastReceiveTime->tv_sec;
         if (time_diff >= 90) {
+            log_debug("dslink_handle_ping: Disconnecting %s due to missing receive\n", link->name );
             broker_close_link(link);
         }
     }

--- a/broker/src/net/ws.c
+++ b/broker/src/net/ws.c
@@ -103,7 +103,11 @@ int broker_ws_send(RemoteDSLink *link, const char *data) {
     if(link->client->poll && !uv_is_closing((uv_handle_t*)link->client->poll)) {
         uv_poll_start(link->client->poll, UV_READABLE | UV_WRITABLE, link->client->poll_cb);
 
-        log_debug("Message sent to %s: %s\n", (char *) link->dsId->data, data);
+        if (link->isUpstream) {
+          log_debug("Message sent to upstrem %s: %s\n", (char *) link->name, data);
+        } else {
+          log_debug("Message sent to %s: %s\n", (char *) link->dsId->data, data);
+        }
 
         return (int)msg.msg_length;
     }

--- a/broker/src/net/ws_handler.c
+++ b/broker/src/net/ws_handler.c
@@ -133,8 +133,13 @@ void broker_on_ws_data(wslay_event_context_ptr ctx,
         if (!data) {
             return;
         }
-        log_debug("Received data from %s: %.*s\n", (char *) link->dsId->data,
-                  (int) arg->msg_length, arg->msg);
+        if (link->isUpstream) {
+          log_debug("Received data from upstream %s: %.*s\n", (char *) link->name,
+                    (int) arg->msg_length, arg->msg);
+        } else {
+          log_debug("Received data from %s: %.*s\n", (char *) link->dsId->data,
+                    (int) arg->msg_length, arg->msg);
+        }
 
         broker_msg_handle(link, data);
         json_decref(data);


### PR DESCRIPTION
This bugfix will handle cases of a "logical" disconnect. This means the TCP connection is still existing, but no linger functional. This may happen depending on different settings int Firewalls/switches/VPN-Gateways, which may keep a TCP connection open to cover unstable network connections (but sometimes its just poor configuration).
In these cases we will detect the disconnect by the missing heartbeat response messages. But the socket will be closed without any notification for the upstream WS handler as the handler is unregistered first. As a consequence the reconnect implemented in the upstream WS handler will not be triggered.
With this fix we will use a modified heartbeat function using as disconnect event for the upstream WS handler to close the non functional upstream instead of just closing the TCP connection.